### PR TITLE
Example Mod: Lua REPL + Command Console

### DIFF
--- a/examples/lua/ReturnOfModding-GlobalExtensions/main.lua
+++ b/examples/lua/ReturnOfModding-GlobalExtensions/main.lua
@@ -1,0 +1,663 @@
+if inext == nil then -- don't run this on refresh
+
+	-- GLOBAL BASE EXTENSIONS
+
+	local unpack = table.unpack
+
+	local function getname( )
+		return debug.getinfo( 2, "n" ).name or "UNKNOWN"
+	end
+
+	local function pusherror( f, ... )
+		local ret = table.pack( pcall( f, ... ) )
+		if ret[ 1 ] then return unpack( ret, 2, ret.n ) end
+		error( ret[ 2 ], 3 )
+	end
+
+	-- doesn't invoke __index
+	_G.rawnext = next
+
+	-- invokes __next
+	function _G.next( t, k )
+		local m = debug.getmetatable( t )
+		local f = m and rawget(m,'__next') or rawnext
+		return pusherror( f, t, k )
+	end
+
+	-- truly raw pairs, ignores __next and __pairs
+	function _G.rawpairs( t )
+		return rawnext, t, nil
+	end
+
+	--[[
+
+	-- quasi-raw pairs, invokes __next but ignores __pairs
+	function qrawpairs( t )
+		return next, t, nil
+	end
+
+	--]]
+
+	-- doesn't invoke __index just like rawnext
+	function _G.rawinext( t, i )
+
+		if type( t ) ~= "table" then
+			error( "bad argument #1 to '" .. getname( ) .. "'(table expected got " .. type( i ) ..")", 2 )
+		end
+
+		if i == nil then
+			i = 0
+		elseif type( i ) ~= "number" then
+			error( "bad argument #2 to '" .. getname( ) .. "'(number expected got " .. type( i ) ..")", 2 )
+		elseif i < 0 then
+			error( "bad argument #2 to '" .. getname( ) .. "'(index out of bounds, too low)", 2 )
+		end
+
+		i = i + 1
+		local v = rawget( t, i )
+		if v ~= nil then
+			return i, v
+		end
+	end
+
+	-- invokes __inext
+	function _G.inext( t, i )
+		local m = debug.getmetatable( t )
+		local f = m and rawget(m,'__inext') or rawinext
+		return pusherror( f, t, i )
+	end
+
+	-- truly raw ipairs, ignores __inext and __ipairs
+	function _G.rawipairs( t )
+		return function( self, key )
+			return rawinext( self, key )
+		end, t, nil
+	end
+
+	--[[
+
+	-- quasi-raw ipairs, invokes __inext but ignores __ipairs
+	function _G.qrawipairs( t )
+		return function( self, key )
+			return inext( self, key )
+		end, t, nil
+	end
+
+	--]]
+
+	--[[
+
+	table.rawinsert = table.insert
+	local rawinsert = table.rawinsert
+	-- table.insert that respects metamethods
+	function table.insert( list, pos, value )
+		local last = #list
+		if value == nil then
+			value = pos
+			pos = last + 1
+		end
+		if pos < 1 or pos > last + 1 then
+			error( "bad argument #2 to '" .. getname( ) .. "' (position out of bounds)", 2 )
+		end
+		if pos <= last then
+			local i = last
+			repeat
+				list[ i + 1 ] = list[ i ]
+				i = i - 1
+			until i < pos
+		end
+		list[ pos ] = value
+	end
+
+	table.rawremove = table.remove
+	-- table.remove that respects metamethods
+	function table.remove( list, pos )
+		local last = #list
+		if pos == nil then
+			pos = last
+		end
+		if pos < 1 or pos > last then
+			error( "bad argument #2 to '" .. getname( ) .. "' (position out of bounds)", 2 )
+		end
+		local value = list[ pos ]
+		if pos <= last then
+			local i = pos
+			repeat
+				list[ i ] = list[ i + 1 ]
+				i = i + 1
+			until i > last
+		end
+		return value
+	end
+
+	table.rawunpack = table.unpack
+	-- table.unpack that respects metamethods
+	do
+		local function unpack( t, m, i, ... )
+			if i < m then return ... end
+			return unpack( t, m, i - 1, t[ i ], ... )
+		end
+		
+		function table.unpack( list, i, j )
+			return unpack( list, i or 1, j or list.n or #list or 1 )
+		end
+	end
+
+	local rawconcat = table.concat
+	table.rawconcat = rawconcat
+	-- table.concat that respects metamethods and includes more values
+	do
+		local wt = setmetatable( { }, { __mode = 'v' } )
+		function table.concat( tbl, sep, i, j )
+			i = i or 1
+			j = j or tbl.n or #tbl
+			if i > j then return "" end
+			sep = sep or ""
+			local t = rawnext( wt ) or { }
+			rawset( wt, 1, t )
+			for k = i, j, 1 do
+				rawset( t, k, tostring( tbl[ k ] ) )
+			end
+			return rawconcat( t, sep, i, j )
+		end
+	end
+
+	--[[
+		NOTE: Other table functions that need to get updated to respect metamethods
+		- table.sort
+	--]]
+
+	--]]
+
+	function _G.setfenv( fn, env )
+		if type( fn ) ~= "function" then
+			fn = debug.getinfo( ( fn or 1 ) + 1, "f" ).func
+		end
+		local i = 0
+		repeat
+			i = i + 1
+			local name = debug.getupvalue( fn, i )
+			if name == "_ENV" then
+				debug.upvaluejoin( fn, i, ( function( )
+					return env
+				end ), 1 )
+				return env
+			end
+		until not name
+	end
+	
+end
+
+if util == nil then -- don't run this on refresh
+	
+	-- GLOBAL UTILITY EXTENSIONS
+
+	_G.util = {}
+
+	function util.perform_lookup(t,s,f)
+		for k,v in pairs(t) do
+			if f ~= nil then v = f(v) end
+			if v == s then return k end
+		end
+		return nil
+	end
+
+	function util.build_lookup(t,f)
+		local l = {}
+		for k,v in pairs(t) do
+			if f ~= nil then v = f(v) end
+			if v ~= nil then l[v] = k end
+		end
+		return l
+	end
+
+	function util.clear(t)
+		for k in pairs(t) do
+			t[k] = nil
+		end
+	end
+
+	function util.iclear(...)
+		local n = 0
+		for _,t in util.vararg(...) do
+			local l = #t
+			if l > n then n = l end
+		end
+		if n == 0 then return end
+		for _,t in util.vararg(...) do
+			for i = 1, n do
+				t[i] = nil
+			end
+		end
+	end
+
+	function util.merge(m,...)
+		for _,t in util.vararg(...) do
+			for k,v in pairs(t) do
+				m[k] = v
+			end
+		end
+		return m
+	end
+
+	--http://lua-users.org/wiki/util.varargTheSecondClassCitizen
+	do
+		function util.vararg(...)
+			local i, t, l = 0, {}
+			local function iter(...)
+				i = i + 1
+				if i > l then return end
+				return i, t[i]
+			end
+			
+			--i = 0
+			l = select("#", ...)
+			for n = 1, l do
+				t[n] = select(n, ...)
+			end
+			--[[
+			for n = l+1, #t do
+				t[n] = nil
+			end
+			--]]
+			return iter
+		end
+	end
+end
+
+if _G.proxy == nil then -- don't do this on refresh
+
+	-- GLOBAL PROXY EXTENSIONS
+
+	_G.proxy = {}
+
+	local function getstring(o)
+		return o.tostring
+	end
+	
+	local function getnumber(o)
+		return tonumber(o.tostring)
+	end
+
+	local function peval(o)
+		local func = load("return " .. o.tostring)
+		if not func then return nil end
+		local status, value = pcall(func)
+		if not status then return nil end
+		return value
+	end
+	
+	local function null()
+		return nil
+	end
+	
+	local function istrue(o)
+		return o.tostring == 'true'
+	end
+
+	local function getarray(o)
+		return o.array
+	end
+
+	rvalue_marshallers = {
+		[RValueType.REAL] = getnumber,
+		[RValueType.STRING] = getstring,
+		[RValueType.ARRAY] = getarray,
+		[RValueType.PTR] = nil,
+		[RValueType.VEC3] = nil,
+		[RValueType.UNDEFINED] = null,
+		[RValueType.OBJECT] = nil,
+		[RValueType.INT32] = getnumber,
+		[RValueType.VEC4] = nil,
+		[RValueType.MATRIX] = nil,
+		[RValueType.INT64] = getnumber,
+		[RValueType.ACCESSOR] = nil,
+		[RValueType.JSNULL] = null,
+		[RValueType.BOOL] = istrue,
+		[RValueType.ITERATOR] = nil,
+		[RValueType.REF] = nil,
+		[RValueType.UNSET] = null
+	}
+
+	function rvalue_marshall(rvalue)
+		local m = rvalue_marshallers[rvalue.type]
+		if m == nil then return rvalue end
+		return m(rvalue)
+	end
+
+	local function get_name(rvalue)
+		return rvalue.tostring
+	end
+
+	local instance_variables_id_register = setmetatable({},{__mode = "k"})
+
+	local instance_variables_proxy_meta = {
+		__index = function(s,k)
+			local id = instance_variables_id_register[s]
+			return rvalue_marshall(gm.variable_instance_get(id,k))
+		end,
+		__newindex = function(s,k,v)
+			local id = instance_variables_id_register[s]
+			return gm.variable_instance_set(id,k,v)
+		end,
+		__next = function(s,k)
+			local id = instance_variables_id_register[s]
+			local names = gm.variable_instance_get_names(id)
+			if names.type ~= RValueType.ARRAY then return nil end
+			names = names.array
+			local i = k and util.perform_lookup(names,k,get_name) or 0
+			k = names[i+1]
+			if k == nil then return nil end
+			k = k.tostring
+			return k, rvalue_marshall(gm.variable_instance_get(id,k))
+		end,
+		__pairs = function(s,k)
+			local id = instance_variables_id_register[s]
+			local names = gm.variable_instance_get_names(id)
+			if names.type ~= RValueType.ARRAY then return nil end
+			names = names.array
+			local names_lookup = util.build_lookup(names,get_name)
+			return function(_,k)
+				local i = k and names_lookup[k] or 0
+				k = names[i+1]
+				if k == nil then return nil end
+				k = k.tostring
+				return k, rvalue_marshall(gm.variable_instance_get(id,k))
+			end,s,k
+		end
+	}
+
+	function proxy.variables(cinstance_or_id)
+		if type(cinstance_or_id) ~= 'number' then cinstance_or_id = cinstance_or_id.id end
+		local proxy = setmetatable({},instance_variables_proxy_meta)
+		instance_variables_id_register[proxy] = cinstance_or_id
+		return proxy
+	end
+
+	local struct_id_register = setmetatable({},{__mode = "k"})
+
+	local struct_proxy_meta = {
+		__index = function(s,k)
+			local id = struct_id_register[s]
+			return rvalue_marshall(gm.struct_get(id,k))
+		end,
+		__newindex = function(s,k,v)
+			local id = struct_id_register[s]
+			return gm.struct_set(id,k,v)
+		end,
+		__next = function(s,k)
+			local id = struct_id_register[s]
+			local names = gm.struct_get_names(id)
+			if names.type ~= RValueType.ARRAY then return nil end
+			names = names.array
+			local i = k and util.perform_lookup(names,k,get_name) or 0
+			k = names[i+1]
+			if k == nil then return nil end
+			k = k.tostring
+			return k, rvalue_marshall(gm.struct_get(id,k))
+		end,
+		__pairs = function(s,k)
+			local id = struct_id_register[s]
+			local names = gm.struct_get_names(id)
+			if names.type ~= RValueType.ARRAY then return nil end
+			names = names.array
+			local names_lookup = util.build_lookup(names,get_name)
+			return function(_,k)
+				local i = k and names_lookup[k] or 0
+				k = names[i+1]
+				if k == nil then return nil end
+				k = k.tostring
+				return k, rvalue_marshall(gm.struct_get(id,k))
+			end,s,k
+		end
+	}
+
+	proxy.struct = setmetatable({},{
+		__call = function(_,id)
+			local proxy = setmetatable({},struct_proxy_meta)
+			struct_id_register[proxy] = id
+			return proxy
+		end
+	})
+	
+	local struct_variables_id_register = setmetatable({},{__mode = "k"})
+	
+	local struct_variables_proxy_meta = {
+		__index = function(s,k)
+			local id = struct_variables_id_register[s]
+			return rvalue_marshall(gm.variable_struct_get(id,k))
+		end,
+		__newindex = function(s,k,v)
+			local id = struct_variables_id_register[s]
+			return gm.variable_struct_set(id,k,v)
+		end,
+		__next = function(s,k)
+			local id = struct_variables_id_register[s]
+			local names = gm.variable_struct_get_names(id)
+			if names.type ~= RValueType.ARRAY then return nil end
+			names = names.array
+			local i = k and util.perform_lookup(names,k,get_name) or 0
+			k = names[i+1]
+			if k == nil then return nil end
+			k = k.tostring
+			return k, rvalue_marshall(gm.variable_struct_get(id,k))
+		end,
+		__pairs = function(s,k)
+			local id = struct_variables_id_register[s]
+			local names = gm.variable_struct_get_names(id)
+			if names.type ~= RValueType.ARRAY then return nil end
+			names = names.array
+			local names_lookup = util.build_lookup(names,get_name)
+			return function(_,k)
+				local i = k and names_lookup[k] or 0
+				k = names[i+1]
+				if k == nil then return nil end
+				k = k.tostring
+				return k, rvalue_marshall(gm.variable_struct_get(id,k))
+			end,s,k
+		end
+	}
+
+	function proxy.struct.variables(id)
+		local proxy = setmetatable({},struct_variables_proxy_meta)
+		struct_variables_id_register[proxy] = id
+		return proxy
+	end
+
+	local global_variables_proxy_meta = {
+		__index = function(s,k)
+			return rvalue_marshall(gm.variable_global_get(k))
+		end,
+		__newindex = function(s,k,v)
+			return gm.variable_global_set(k,v)
+		end,
+		__next = function(s,k)
+			local names = gm.variable_instance_get_names(EVariableType.GLOBAL)
+			if names.type ~= RValueType.ARRAY then return nil end
+			names = names.array
+			local i = k and util.perform_lookup(names,k,get_name) or 0
+			k = names[i+1]
+			if k == nil then return nil end
+			k = k.tostring
+			return k, rvalue_marshall(gm.variable_global_get(k))
+		end,
+		__pairs = function(s,k)
+			local names = gm.variable_instance_get_names(EVariableType.GLOBAL)
+			if names.type ~= RValueType.ARRAY then return nil end
+			names = names.array
+			local names_lookup = util.build_lookup(names,get_name)
+			return function(_,k)
+				local i = k and names_lookup[k] or 0
+				k = names[i+1]
+				if k == nil then return nil end
+				k = k.tostring
+				return k, rvalue_marshall(gm.variable_global_get(k))
+			end,s,k
+		end
+	}
+
+	proxy.globals = setmetatable({},global_variables_proxy_meta)
+	
+	local function get_asset(asset_name,asset_type)
+		if asset_type == 'script' then return gm[asset_name] end
+		--return gm.asset_get_index(asset_name)
+		return gm.constants[asset_name]
+	end
+	
+	proxy.constants = {}
+	local constants_lookup = {}
+	local constants_proxy_meta = {}
+	
+	for t,v in pairs(gm.constants_type_sorted) do
+		constants_lookup[t] = util.build_lookup(v)
+		constants_proxy_meta[t] = {
+			__index = function(s,k)
+				return get_asset(k,t)
+			end,
+			__newindex = function(s,k,v)
+				error(2,"cannot override gamemaker asset.")
+			end,
+			__next = function(s,k)
+				local k = next(constants_lookup[t],k)
+				return k, get_asset(k,t)
+			end,
+			__pairs = function(s,k)
+				return function(s,k)
+					local k = next(constants_lookup[t],k)
+					return k, get_asset(k,t)
+				end,s,k
+			end
+		}
+		proxy.constants[t] = setmetatable({},constants_proxy_meta[t])
+	end
+	
+end
+
+if ImGui.GetStyleVar == nil then -- don't do this on refresh
+
+	-- GLOBAL OBJECT EXTENSIONS
+
+	local function endow_with_pairs_and_next(sol_object)
+		-- this should be idempotent (does nothing extra when applied more than once)
+		--[[
+		context behind this approach:
+			sol objects are userdata or tables that have sol classes as metatables
+			sol object attributes are functions in their sol class as the same field
+			sol class __index function fallsback to itself so objects inherit class members
+			sol __index generates a new 'new' function whenever it is requested
+			sol classes have stub __pairs that just errors when called
+			sol overrides next to error when that is used on a sol class
+		--]]
+		local sol_meta = getmetatable(sol_object)
+		if not sol_meta then return end
+		local status, sol_next
+		if rawget(sol_meta,'__pairs') or rawget(sol_meta,'__next') then
+			status, sol_next = pcall(pairs,sol_object)
+		end
+		if not status then
+			local sol_index = rawget(sol_meta,'__index')
+			if not sol_index then return end
+			if type(sol_index) ~= 'function' then
+				function sol_next(s,k)
+					return next(sol_index,k)
+				end
+			else
+				function sol_next(s,k)
+					local v,u,w
+					while v == nil do
+						k,u = rawnext(sol_meta,k)
+						if k == nil then return nil end
+						-- ignore 'new' and metatable fields
+						if k ~= 'new' and k:sub(1,2) ~= '__' then
+							w = s[k]
+							-- if the object reports a value different to the class
+							if u ~= w then
+								-- assume it's actually that object's attribute
+								v = w
+							end
+						end
+					end
+					return k,v
+				end
+			end
+			rawset(sol_meta,'__pairs',function(s,k)
+				return sol_next,s,k
+			end)
+		end
+		-- __next is implemented by a custom implementation of next
+		local status = pcall(rawnext,sol_object)
+		if not status and sol_next ~= nil and rawget(sol_meta,'__next') == nil then
+			rawset(sol_meta,'__next',sol_next)
+		end
+	end
+
+	local function endow_with_new_properties(sol_object,properties)
+		local meta = getmetatable(sol_object)
+		local new_properties = {}
+		for k,v in pairs(properties) do
+			if not rawget(meta,k) then
+				new_properties[k] = v
+				rawset(meta,k,v)
+			end
+		end
+		local index = meta.__index
+		meta.__index = function(s,k)
+			local v = new_properties[k]
+			if v then return v(s) end
+			return index(s,k)
+		end
+	end
+
+	local function on_delayed_load()
+		local gm_instance_list = gm.CInstance.instances_all
+		local gm_instance = gm_instance_list[1]
+		if not gm_instance then return false end
+		local gm_rvalue = gm.variable_global_get("mouse_x")
+		
+		local imgui_style = ImGui.GetStyle() -- sol.ImGuiStyle*
+		local imgui_vector = imgui_style["WindowPadding"] -- sol.ImVec2*
+		endow_with_pairs_and_next(imgui_style)
+		endow_with_pairs_and_next(imgui_vector)
+
+		endow_with_pairs_and_next(gm_instance_list)
+		endow_with_pairs_and_next(gm_instance)
+		endow_with_pairs_and_next(gm_rvalue)
+		endow_with_pairs_and_next(RValueType)
+		
+		local rvalue_lookup = util.build_lookup(RValueType)
+		endow_with_new_properties(gm_rvalue,{
+			type_name = function(s) return rvalue_lookup[s.type] end,
+			lua_value = rvalue_marshall
+		})
+		endow_with_new_properties(gm_instance,{
+			variables = proxy.variables
+		})
+		
+		if ImGui.GetStyleVar == nil then
+			local imgui_vector_meta = getmetatable(imgui_vector)
+			local imgui_stylevar_lookup = util.build_lookup(ImGuiStyleVar)
+			imgui_stylevar_lookup[ImGuiStyleVar.COUNT] = nil
+
+			function ImGui.GetStyleVar(var)
+				if type(var) == "number" then
+					var = imgui_stylevar_lookup[var]
+				end
+				local s = ImGui.GetStyle()[var]
+				if getmetatable(s) ~= imgui_vector_meta then return s end
+				return s['x'],s['y']
+			end
+		end
+		
+		return true
+	end
+
+	local next_delayed_load = on_delayed_load
+
+	local function imgui_on_render()
+		if next_delayed_load and next_delayed_load() then
+			next_delayed_load = nil
+		end
+	end
+
+	gui.add_imgui(imgui_on_render)
+end

--- a/examples/lua/ReturnOfModding-GlobalExtensions/manifest.json
+++ b/examples/lua/ReturnOfModding-GlobalExtensions/manifest.json
@@ -1,0 +1,9 @@
+﻿{
+	"name": "GlobalExtensions",
+	"version_number": "1.0.0",
+	"website_url": "https://github.com/return-of-modding/ReturnOfModding",
+	"description": "Default extensions to the lua API",
+	"dependencies": [
+		"ReturnOfModding-ReturnOfModding-1.0.0"
+	]
+}

--- a/examples/lua/ReturnOfModding-ScriptConsole/main.lua
+++ b/examples/lua/ReturnOfModding-ScriptConsole/main.lua
@@ -1140,7 +1140,7 @@ function imgui_on_render()
 					end
 					ImGui.PushItemWidth(x_input)
 					ImGui.PushStyleVar(ImGuiStyleVar.FramePadding, frame_padding_x, y_input)
-					md.current_text, md.enter_pressed = ImGui.InputText("##Text" .. ms, md.current_text, 512, ImGuiInputTextFlags.EnterReturnsTrue)
+					md.current_text, md.enter_pressed = ImGui.InputText("##Text" .. ms, md.current_text, 65535, ImGuiInputTextFlags.EnterReturnsTrue)
 					ImGui.PopStyleVar()
 					ImGui.PopItemWidth()
 					local changed_offset

--- a/examples/lua/ReturnOfModding-ScriptConsole/main.lua
+++ b/examples/lua/ReturnOfModding-ScriptConsole/main.lua
@@ -864,20 +864,23 @@ do
 
 	function cinstance_variables_proxy(cinstance)
 		local proxy = setmetatable({},cinstance_variables_proxy_meta)
-		cinstance_variables_id_register[proxy] = cinstance.i_id
+		cinstance_variables_id_register[proxy] = cinstance.id
 		return proxy
 	end
 end
 
 function on_delayed_load()
-	local imgui_style = ImGui.GetStyle() -- sol.ImGuiStyle*
-	local imgui_vector = imgui_style["WindowPadding"] -- sol.ImVec2*
+
 	local gm_instance_list = gm.CInstance.instances_all
 	local gm_instance = gm_instance_list[1]
+	if not gm_instance then return false end
 	local gm_rvalue = gm.variable_global_get("mouse_x")
-
+	
+	local imgui_style = ImGui.GetStyle() -- sol.ImGuiStyle*
+	local imgui_vector = imgui_style["WindowPadding"] -- sol.ImVec2*
 	endow_with_pairs_and_next(imgui_style)
 	endow_with_pairs_and_next(imgui_vector)
+
 	endow_with_pairs_and_next(gm_instance_list)
 	endow_with_pairs_and_next(gm_instance)
 	endow_with_pairs_and_next(gm_rvalue)
@@ -903,13 +906,14 @@ function on_delayed_load()
 			return s['x'],s['y']
 		end
 	end
+	
+	return true
 end
 
 local next_delayed_load = on_delayed_load
 
 function imgui_on_render()
-	if next_delayed_load then
-		next_delayed_load()
+	if next_delayed_load and next_delayed_load() then
 		next_delayed_load = nil
 	end
 	if ImGui.Begin("Script Console") then

--- a/examples/lua/ReturnOfModding-ScriptConsole/main.lua
+++ b/examples/lua/ReturnOfModding-ScriptConsole/main.lua
@@ -958,10 +958,10 @@ do
 
 	local global_variables_proxy_meta = {
 		__index = function(s,k)
-			return rvalue_marshall(gm.variable_instance_get(EVariableType.GLOBAL,k))
+			return rvalue_marshall(gm.variable_global_get(k))
 		end,
 		__newindex = function(s,k,v)
-			return gm.variable_instance_set(EVariableType.GLOBAL,k,v)
+			return gm.variable_global_set(k,v)
 		end,
 		__next = function(s,k)
 			local names = gm.variable_instance_get_names(EVariableType.GLOBAL)
@@ -971,7 +971,7 @@ do
 			k = names[i+1]
 			if k == nil then return nil end
 			k = k.tostring
-			return k, rvalue_marshall(gm.variable_instance_get(EVariableType.GLOBAL,k))
+			return k, rvalue_marshall(gm.variable_global_get(k))
 		end,
 		__pairs = function(s,k)
 			local names = gm.variable_instance_get_names(EVariableType.GLOBAL)
@@ -983,7 +983,7 @@ do
 				k = names[i+1]
 				if k == nil then return nil end
 				k = k.tostring
-				return k, rvalue_marshall(gm.variable_instance_get(EVariableType.GLOBAL,k))
+				return k, rvalue_marshall(gm.variable_global_get(k))
 			end,s,k
 		end
 	}

--- a/examples/lua/ReturnOfModding-ScriptConsole/main.lua
+++ b/examples/lua/ReturnOfModding-ScriptConsole/main.lua
@@ -1,5 +1,7 @@
 log.info("Script Console Startup...")
 
+local mod_guid = "ReturnOfModding-ScriptConsole"
+
 local _repl_globals = {}
 for k,v in pairs(_G) do
 	_repl_globals[k] = v
@@ -243,7 +245,7 @@ end
 autoexec_name = "autoexec"
 
 function get_data_path()
-	return paths.plugins_data(_ENV)
+	return paths.plugins_data() .. '/' .. mod_guid
 end
 
 function run_console_command(mi, text)
@@ -309,6 +311,7 @@ console_commands = {
 		for _, arg in vararg(...) do
 			text = text .. ' ' .. arg
 		end
+		text = text:sub(2,#text)
 		return mlog.echo(mi,true,text)
 	end,
 	lua = function(mi,...)
@@ -316,6 +319,7 @@ console_commands = {
 		for _, arg in vararg(...) do
 			text = text .. ' ' .. arg
 		end
+		text = text:sub(2,#text)
 		if #text == 0 then
 			return mlog.error(mi, true, "cannot execute empty lua code.")
 		end
@@ -369,6 +373,7 @@ console_commands = {
 		for _, arg in vararg(...) do
 			text = text .. ' ' .. arg
 		end
+		text = text:sub(2,#text)
 		if #text == 0 then
 			local msg = console_aliases[name]
 			if not msg then 

--- a/examples/lua/ReturnOfModding-ScriptConsole/main.lua
+++ b/examples/lua/ReturnOfModding-ScriptConsole/main.lua
@@ -335,7 +335,7 @@ for k in pairs(mlog_colors) do
 		table.insert(console_mode_lines[mi], mlog_prefixes_shown[k] .. text)
 		console_mode_color[mi][#console_mode_lines[mi]] = mlog_colors[k]
 		if mlog_loggers[k] then
-			return log.error( mlog_prefixes_debug[k] .. console_mode_prefix[mi] .. text )
+			return mlog_loggers[k]( mlog_prefixes_debug[k] .. console_mode_prefix[mi] .. text )
 		end
 	end
 end

--- a/examples/lua/ReturnOfModding-ScriptConsole/main.lua
+++ b/examples/lua/ReturnOfModding-ScriptConsole/main.lua
@@ -1,0 +1,528 @@
+log.info("Script Console Startup...")
+
+local _repl_globals = {}
+for k,v in pairs(_G) do
+	_repl_globals[k] = v
+end
+repl_globals = _repl_globals
+repl_environment = setmetatable( { }, {
+	__index = repl_globals,
+	__newindex = repl_globals
+} )
+
+function lookup(t)
+	local l = {}
+	for k,v in pairs(t) do
+		l[v] = k
+	end
+	return l
+end
+
+--http://lua-users.org/wiki/VarargTheSecondClassCitizen
+do
+	local i, t, l = 0, {}
+	local function iter(...)
+		i = i + 1
+		if i > l then return end
+		return i, t[i]
+	end
+
+	function vararg(...)
+		i = 0
+		l = select("#", ...)
+		for n = 1, l do
+			t[n] = select(n, ...)
+		end
+		for n = l+1, #t do
+			t[n] = nil
+		end
+		return iter
+	end
+end
+
+do
+	local varargmap_buffer = { }
+	function varargmap( map, ... )
+		for k in pairs(varargmap_buffer) do
+			varargmap_buffer[k] = nil
+		end
+		local n = 0
+		for i, a in vararg(...) do
+			n = i
+			varargmap_buffer[i] = map(a)
+		end
+		return table.unpack(varargmap_buffer, 1, n)
+	end
+end
+
+function setfenv( fn, env )
+	if type( fn ) ~= "function" then
+		fn = debug.getinfo( ( fn or 1 ) + 1, "f" ).func
+	end
+	local i = 0
+	repeat
+		i = i + 1
+		local name = debug.getupvalue( fn, i )
+		if name == "_ENV" then
+			debug.upvaluejoin( fn, i, ( function( )
+				return env
+			end ), 1 )
+			return env
+		end
+	until not name
+end
+
+function tostring_literal(value)
+	-- TODO: expand tables python-style?
+	if type(value) == "string" then
+		local lined, _lined = 0, value:gmatch("\n")
+		for _ in _lined do lined = lined + 1 end
+		local dquoted, _dquoted = 0, value:gmatch([=["]=])
+		for _ in _dquoted do dquoted = dquoted + 1 end
+		local squoted, _squoted = 0, value:gmatch([=[']=])
+		for _ in _squoted do squoted = squoted + 1 end
+		local edquoted, _edquoted = 0, value:gmatch([=[\"]=])
+		if lined > 0 or (dquoted > 0 and squoted > 0) then
+			local special, _special = 0, value:gmatch([=[[=]]=])
+			for _ in _special do special = special + 1 end
+			local eq = "="
+			for i = 1, special do
+				eq = eq .. '='
+			end
+			return '['..eq..'[' .. value .. ']'..eq..']'
+		elseif squoted > 0 then
+			return '"' .. value .. '"'
+		else
+			return "'" .. value .. "'"
+		end
+	end
+	return tostring(value)
+end
+
+function vararg_tostring(raw, ...)
+	s = ""
+	for _,v in vararg(...) do
+		v = raw and tostring(v) or tostring_literal(v)
+		s = s .. '\t' .. v
+	end
+	return s:sub(2,#s)
+end
+
+mlog_prefixes_debug = {
+	error = "",
+	info = "",
+	warning = "",
+	history = "",
+	echo = "[Echo]:",
+	print = "[Print]:",
+	returns = "[Returns]:"
+}
+
+mlog_prefixes_shown = {
+	error = "",
+	info = "",
+	warning = "",
+	history = "] ",
+	echo = "",
+	print = "",
+	returns = ""
+}
+
+mlog_loggers = {
+	error = log.error,
+	info = log.info,
+	warning = log.warning,
+	history = false,
+	echo = log.info,
+	print = log.info,
+	returns = log.info
+}
+
+mlog_colors = {
+	error = 0xFF2020EE,
+	info = 0xFFEEEEEE,
+	warning = 0xFF20EEEE,
+	history = 0xEECCCCCC,
+	echo = 0xFFEEEEEE,
+	print = 0xFFEEEEEE,
+	returns = 0xFFFFFF20
+}
+
+mlog = {}
+for k in pairs(mlog_colors) do
+	mlog[k] = function(mi, raw, ...)
+		local text = vararg_tostring(raw, ...)
+		table.insert(console_mode_raw[mi], text)
+		table.insert(console_mode_lines[mi], mlog_prefixes_shown[k] .. text)
+		console_mode_color[mi][#console_mode_lines[mi]] = mlog_colors[k]
+		if mlog_loggers[k] then
+			return log.error( mlog_prefixes_debug[k] .. console_mode_prefix[mi] .. text )
+		end
+	end
+end
+
+function repl_execute_lua(mi, env, text, ...)
+	repl_globals.print = console_mode_print[mi]
+	local func, err = text, ''
+	if type(text) == "string" then
+		func, err = load( "return " .. text )
+		if not func then
+			func, err = load( text )
+			if not func then
+				return false, err
+			end
+		end
+	end
+	if env then
+		setfenv( func, env == true and repl_environment or env )
+	end
+	return pcall( func, ... )
+end
+
+--https://stackoverflow.com/a/28664691
+do 
+	-- TODO: This needs to be improved regarding properly handling embedded and mixed quotes!
+	local parse_command_text_buffer = {}
+	function parse_command_text(text)
+		for k in pairs(parse_command_text_buffer) do
+			parse_command_text_buffer[k] = nil
+		end
+		local spat, epat, buf, quoted = [=[^(['"])]=], [=[(['"])$]=]
+		for str in text:gmatch("%S+") do
+			local squoted = str:match(spat)
+			local equoted = str:match(epat)
+			local escaped = str:match([=[(\*)['"]$]=])
+			if squoted and not quoted and not equoted then
+				buf, quoted = str, squoted
+			elseif buf and equoted == quoted and #escaped % 2 == 0 then
+				str, buf, quoted = buf .. ' ' .. str, nil, nil
+			elseif buf then
+				buf = buf .. ' ' .. str
+			end
+			if not buf then
+				local token = str:gsub(spat,""):gsub(epat,"")
+				table.insert(parse_command_text_buffer,token)
+			end
+		end
+		if buf then return false, "Missing matching quote for "..buf end
+		return true, table.unpack(parse_command_text_buffer)
+	end
+	local parse_multicommand_text_buffer = {}
+	function parse_multicommand_text(text)
+		for k in pairs(parse_multicommand_text_buffer) do
+				parse_multicommand_text_buffer[k] = nil
+		end
+		for mstr in text:gmatch("[^\r\n]+") do
+			local pquoted, buf = 0
+			for str in mstr:gmatch("[^;]+") do
+				str = str:gsub("^%s\\*", "")
+				local quoted, _quoted = 0, str:gmatch([=[['"]]=])
+				for _ in _quoted do quoted = quoted + 1 end
+				local escaped, _escaped = 0, str:gmatch([=[\['"]]=])
+				for _ in _escaped do escaped = escaped + 1 end
+				pquoted = (pquoted+quoted-escaped) % 2
+				if not buf and pquoted == 1 then
+					buf = str
+				elseif buf and pquoted == 0 then
+					str, buf = buf .. ';' .. str, nil
+				elseif buf and pquoted == 1 then
+					buf = buf .. ';' .. str
+					str, buf, quoted = buf .. ';' .. str, nil, 0
+				end
+				if not buf then
+					local token = str
+					table.insert(parse_multicommand_text_buffer,token)
+				end
+			end
+			if buf then return false, "Missing matching quote for "..buf end
+		end
+		return true, table.unpack(parse_multicommand_text_buffer)
+	end
+end
+
+autoexec_name = "autoexec"
+
+function get_data_path()
+	return paths.plugins_data(_ENV)
+end
+
+function run_console_command(mi, text)
+		local parse_result = table.pack(parse_command_text(text))
+		local status, command_name = parse_result[1], parse_result[2]
+		if not status then
+			mlog.error(mi, true, command_name)
+		end
+		local alias = console_aliases[command_name]
+		if alias ~= nil then
+			return run_console_multicommand(mi, alias)
+		end
+		local command = console_commands[command_name]
+		if command == nil then
+			return mlog.error(mi, true, 'no command by the name of "' .. command_name .. '" found')
+		end
+		local ret = table.pack(repl_execute_lua(mi, false, command, mi, table.unpack(parse_result, 3, parse_result.n)))
+		if ret.n <= 1 then return end
+		if ret[1] == false then
+			return mlog.error( mi, true, ret[2] )
+		end
+		return mlog.info(mi, false, table.unpack( ret, 2, ret.n ))
+end
+
+function run_console_multicommand(mi, text)
+		local parse_result = table.pack(parse_multicommand_text(text))
+		local status, err = parse_result[1], parse_result[2]
+		if not status then
+			mlog.error(mi, true, err)
+		end
+		table.unpack(parse_result, 2, parse_result.n)
+		for i = 2, parse_result.n do
+			run_console_command(mi, parse_result[i])
+		end
+end
+
+console_aliases = {}
+
+console_commands_help = {
+	{"help","[0..1]","lists the available commands"},
+	{"echo","[..]","prints a message to the console"},
+	{"lua","[1..]","executes lua code and shows the result"},
+	{"luae","[1]","executes lua file with args and shows the result"},
+	{"exec","[1]","executes a file containing a list of console commands"},
+	{"alias","[0..2]","defines a command that acts as a shortcut for other commands"}
+}
+
+console_commands = {
+	help = function(mi,stub)
+		if stub then
+			local msg = console_commands_help[stub]
+			if not msg then 
+				return mlog.error(mi, true, 'no command by the name of "' .. stub .. '" found')
+			end
+			return mlog.echo(mi, true, msg)
+		end
+		for _,h in ipairs(console_commands_help) do
+			mlog.echo(mi, true, table.unpack(h))
+		end
+	end,
+	echo = function(mi,...)
+		local text = ""
+		for _, arg in vararg(...) do
+			text = text .. ' ' .. arg
+		end
+		return mlog.echo(mi,true,text)
+	end,
+	lua = function(mi,...)
+		local text = ""
+		for _, arg in vararg(...) do
+			text = text .. ' ' .. arg
+		end
+		if #text == 0 then
+			return mlog.error(mi, true, "cannot execute empty lua code.")
+		end
+		local ret = table.pack(repl_execute_lua(mi, true, text))
+		if ret.n <= 1 then return end
+		if ret[1] == false then
+			return mlog.error( mi, true, ret[2] )
+		end
+		return mlog.returns(mi, false, table.unpack( ret, 2, ret.n ))
+	end,
+	--https://stackoverflow.com/a/10387949
+	luae = function(mi,path,...)
+		qualpath = get_data_path() .. '/' .. path
+		local file = io.open(qualpath,"rb")
+		if not file or type(file) == "string" or type(file) == "number" then
+			file = io.open(qualpath .. ".lua","rb")
+			if not file or type(file) == "string" or type(file) == "number" then
+				return mlog.warning(mi, true, 'attempted to read the lua file "' .. path .. '", but failed.')
+			end
+		end
+		local data = file:read("*a")
+		file:close()
+		local ret = table.pack(repl_execute_lua(mi, true, data, ...))
+		if ret.n <= 1 then return end
+		if ret[1] == false then
+			return mlog.error( mi, true, ret[2] )
+		end
+		return mlog.returns(mi, false, table.unpack( ret, 2, ret.n ))
+	end,
+	exec = function(mi,path)
+		qualpath = get_data_path() .. '/' .. path
+		local file = io.open(qualpath,"rb")
+		if not file or type(file) == "string" or type(file) == "number" then
+			file = io.open(qualpath .. ".txt","rb")
+			if not file or type(file) == "string" or type(file) == "number" then
+				return mlog.warning(mi, true, 'attempted to read the batch file "' .. path .. '", but failed.')
+			end
+		end
+		local data = file:read("*a")
+		file:close()
+		return run_console_multicommand(mi,data)
+	end,
+	alias = function(mi,name,...)
+		if name == nil then
+			for k,v in pairs(console_aliases) do
+				mlog.echo(mi, true, k,v)
+			end
+			return
+		end
+		local text = ""
+		for _, arg in vararg(...) do
+			text = text .. ' ' .. arg
+		end
+		if #text == 0 then
+			local msg = console_aliases[name]
+			if not msg then 
+				return mlog.error(mi, true, 'no alias by the name of "' .. name .. '" exists')
+			end
+			return mlog.echo(mi, true, msg)
+		end
+		console_aliases[name] = text
+	end,
+}
+
+console_modes_lookup = {
+	"Command Console",
+	"Lua Script REPL"
+}
+console_modes = lookup(console_modes_lookup)
+
+console_mode_history = {}
+console_mode_history_offset = {}
+console_mode_lines = {}
+console_mode_raw = {}
+console_mode_text = {}
+console_mode_selected = {}
+console_mode_color = {}
+console_mode_print = {}
+for mi in ipairs(console_modes_lookup) do
+	console_mode_history[mi] = {}
+	console_mode_history_offset[mi] = 0
+	console_mode_lines[mi] = {}
+	console_mode_raw[mi] = {}
+	console_mode_text[mi] = ""
+	console_mode_selected[mi] = {}
+	console_mode_color[mi] = {}
+	console_mode_print[mi] = function(...) return mlog.print(mi,true,...) end
+end
+
+console_mode_prefix = {
+	"[Console]:",
+	"[LuaREPL]:",
+}
+
+console_mode_on_enter = {
+	function(mi,text) -- Command Console
+		mlog.history(mi, true, text)
+		return run_console_multicommand(mi, text)
+	end,
+	function(mi,text) -- Lua Script REPL
+		mlog.history(mi, true, text)
+		local ret = table.pack( repl_execute_lua(mi, true, text) )
+		if ret.n <= 1 then return end
+		if ret[1] == false then
+			return mlog.error( mi, true, ret[2] )
+		end
+		return mlog.returns(mi, false, table.unpack( ret, 2, ret.n ))
+	end
+}
+
+function imgui_on_render()
+	local tx, ty = ImGui.CalcTextSize('||||||||||||||||||||||');
+	local tx2, ty2, tx0_5, tx1_5 = 2*tx, 2*ty, 0.5*tx, 1.5*tx
+	if ImGui.Begin("Script Console") then
+		if ImGui.BeginTabBar("Mode",ImGuiTabBarFlags.Reorderable) then
+			local x,y = ImGui.GetContentRegionAvail()
+			for mi,ds in ipairs(console_modes_lookup) do
+				local ms = tostring(mi)
+				if ImGui.BeginTabItem(ds) then
+					ImGui.EndTabItem()
+					if autoexec_name then
+						local name = autoexec_name
+						autoexec_name = nil
+						run_console_command(mi,"exec " .. name)
+					end
+					if ImGui.BeginListBox("##Box" .. ms,x,y-ty2) then
+						for li,ls in ipairs(console_mode_lines[mi]) do
+							local _, y = ImGui.CalcTextSize(ls)
+							console_mode_selected[mi][li] = ImGui.Selectable("##Select" .. ms .. tostring(li), console_mode_selected[mi][li] or false, ImGuiSelectableFlags.AllowDoubleClick, 0, y)
+							if ImGui.IsItemHovered() and ImGui.IsItemClicked(ImGuiMouseButton.Right) then
+								local selected = not console_mode_selected[mi][li]
+								for oli in ipairs(console_mode_lines[mi]) do
+									console_mode_selected[mi][oli] = selected
+								end
+							end
+							ImGui.SameLine()
+							local color = console_mode_color[mi][li]
+							if color ~= nil then ImGui.PushStyleColor(ImGuiCol.Text, color) end
+							ImGui.TextWrapped(ls)
+							if color ~= nil then ImGui.PopStyleColor() end
+						end
+						ImGui.EndListBox()
+					end
+					local enter
+					ImGui.PushItemWidth(x-tx1_5)
+					console_mode_text[mi], enter = ImGui.InputText("##Text" .. ms, console_mode_text[mi], 512, ImGuiInputTextFlags.EnterReturnsTrue)
+					ImGui.PopItemWidth()
+					if enter then
+						local text = console_mode_text[mi]
+						table.insert(console_mode_history[mi],text)
+						console_mode_history_offset[mi] = 0
+						console_mode_text[mi] = ""
+						console_mode_on_enter[mi](mi, text)
+					end
+					local changed_offset
+					ImGui.SameLine()
+					if ImGui.Button("^##" .. ms) then
+						console_mode_history_offset[mi] = console_mode_history_offset[mi] + 1
+						if console_mode_history_offset[mi] > #console_mode_history[mi] then
+							console_mode_history_offset[mi] = #console_mode_history[mi]
+						end
+						changed_offset = true
+					end
+					ImGui.PushItemWidth(tx0_5)
+					ImGui.SameLine()
+					if ImGui.Button("v##" .. ms) then
+						console_mode_history_offset[mi] = console_mode_history_offset[mi] - 1
+						if console_mode_history_offset[mi] < 0 then
+							console_mode_history_offset[mi] = 0
+						end
+						changed_offset = true
+					end
+					if changed_offset then
+						if console_mode_history_offset[mi] == 0 then
+							console_mode_text[mi] = ""
+						else
+							console_mode_text[mi] = console_mode_history[mi][#console_mode_history[mi]-console_mode_history_offset[mi]+1]
+						end
+					end
+					ImGui.PopItemWidth()
+					ImGui.PushItemWidth(tx)
+					--ImGui.SameLine()
+					--if ImGui.Button("< Paste##" .. ms) then
+					--	console_mode_text[mi] = ImGui.GetClipboardText()
+					--end
+					ImGui.SameLine()
+					if ImGui.Button("Copy ^##" .. ms) then
+						local text
+						for hi,b in ipairs(console_mode_selected[mi]) do
+							if b then 
+								local line = console_mode_raw[mi][hi] or console_mode_lines[mi][hi]
+								if text == nil then
+									text = line
+								else
+									text = text .. '\n' .. line
+								end
+							end
+						end
+						ImGui.SetClipboardText(text)
+					end
+					ImGui.PopItemWidth()
+				end
+			end
+			ImGui.EndTabBar()
+		end
+	end
+	ImGui.End()
+end
+
+gui.add_imgui(imgui_on_render)

--- a/examples/lua/ReturnOfModding-ScriptConsole/main.lua
+++ b/examples/lua/ReturnOfModding-ScriptConsole/main.lua
@@ -1,262 +1,5 @@
--- BASE EXTENSIONS: Should be rolled into the base API if desired
-
-local unpack = table.unpack
-
-local function getname( )
-	return debug.getinfo( 2, "n" ).name or "UNKNOWN"
-end
-
-local function pusherror( f, ... )
-	local ret = table.pack( pcall( f, ... ) )
-	if ret[ 1 ] then return unpack( ret, 2, ret.n ) end
-	error( ret[ 2 ], 3 )
-end
-
--- doesn't invoke __index
-rawnext = next
-
--- invokes __next
-function next( t, k )
-	local m = debug.getmetatable( t )
-	local f = m and rawget(m,'__next') or rawnext
-	return pusherror( f, t, k )
-end
-
--- truly raw pairs, ignores __next and __pairs
-function rawpairs( t )
-	return rawnext, t, nil
-end
-
---[[
-
--- quasi-raw pairs, invokes __next but ignores __pairs
-function qrawpairs( t )
-    return next, t, nil
-end
-
---]]
-
--- doesn't invoke __index just like rawnext
-function rawinext( t, i )
-
-	if type( t ) ~= "table" then
-		error( "bad argument #1 to '" .. getname( ) .. "'(table expected got " .. type( i ) ..")", 2 )
-	end
-
-	if i == nil then
-		i = 0
-	elseif type( i ) ~= "number" then
-		error( "bad argument #2 to '" .. getname( ) .. "'(number expected got " .. type( i ) ..")", 2 )
-	elseif i < 0 then
-		error( "bad argument #2 to '" .. getname( ) .. "'(index out of bounds, too low)", 2 )
-	end
-
-	i = i + 1
-	local v = rawget( t, i )
-	if v ~= nil then
-		return i, v
-	end
-end
-
--- invokes __inext
-function inext( t, i )
-	local m = debug.getmetatable( t )
-	local f = m and rawget(m,'__inext') or rawinext
-	return pusherror( f, t, i )
-end
-
--- truly raw ipairs, ignores __inext and __ipairs
-function rawipairs( t )
-	return function( self, key )
-		return rawinext( self, key )
-	end, t, nil
-end
-
---[[
-
--- quasi-raw ipairs, invokes __inext but ignores __ipairs
-function qrawipairs( t )
-	return function( self, key )
-		return inext( self, key )
-	end, t, nil
-end
-
---]]
-
---[[
-
-table.rawinsert = table.insert
-local rawinsert = table.rawinsert
--- table.insert that respects metamethods
-function table.insert( list, pos, value )
-	local last = #list
-	if value == nil then
-		value = pos
-		pos = last + 1
-	end
-	if pos < 1 or pos > last + 1 then
-		error( "bad argument #2 to '" .. getname( ) .. "' (position out of bounds)", 2 )
-	end
-	if pos <= last then
-		local i = last
-		repeat
-			list[ i + 1 ] = list[ i ]
-			i = i - 1
-		until i < pos
-	end
-	list[ pos ] = value
-end
-
-table.rawremove = table.remove
--- table.remove that respects metamethods
-function table.remove( list, pos )
-	local last = #list
-	if pos == nil then
-		pos = last
-	end
-	if pos < 1 or pos > last then
-		error( "bad argument #2 to '" .. getname( ) .. "' (position out of bounds)", 2 )
-	end
-	local value = list[ pos ]
-	if pos <= last then
-		local i = pos
-		repeat
-			list[ i ] = list[ i + 1 ]
-			i = i + 1
-		until i > last
-	end
-	return value
-end
-
-table.rawunpack = table.unpack
--- table.unpack that respects metamethods
-do
-	local function unpack( t, m, i, ... )
-		if i < m then return ... end
-		return unpack( t, m, i - 1, t[ i ], ... )
-	end
-	
-	function table.unpack( list, i, j )
-		return unpack( list, i or 1, j or list.n or #list or 1 )
-	end
-end
-
-local rawconcat = table.concat
-table.rawconcat = rawconcat
--- table.concat that respects metamethods and includes more values
-do
-	local wt = setmetatable( { }, { __mode = 'v' } )
-	function table.concat( tbl, sep, i, j )
-		i = i or 1
-		j = j or tbl.n or #tbl
-		if i > j then return "" end
-		sep = sep or ""
-		local t = rawnext( wt ) or { }
-		rawset( wt, 1, t )
-		for k = i, j, 1 do
-			rawset( t, k, tostring( tbl[ k ] ) )
-		end
-		return rawconcat( t, sep, i, j )
-	end
-end
-
---[[
-	NOTE: Other table functions that need to get updated to respect metamethods
-	- table.sort
---]]
-
---]]
-
-function setfenv( fn, env )
-	if type( fn ) ~= "function" then
-		fn = debug.getinfo( ( fn or 1 ) + 1, "f" ).func
-	end
-	local i = 0
-	repeat
-		i = i + 1
-		local name = debug.getupvalue( fn, i )
-		if name == "_ENV" then
-			debug.upvaluejoin( fn, i, ( function( )
-				return env
-			end ), 1 )
-			return env
-		end
-	until not name
-end
-
-function perform_lookup(t,s,f)
-	for k,v in pairs(t) do
-		if f ~= nil then v = f(v) end
-		if v == s then return k end
-	end
-	return nil
-end
-
-function build_lookup(t,f)
-	local l = {}
-	for k,v in pairs(t) do
-		if f ~= nil then v = f(v) end
-		if v ~= nil then l[v] = k end
-	end
-	return l
-end
-
-function clear(t)
-	for k in pairs(t) do
-		t[k] = nil
-	end
-end
-
-function iclear(...)
-	local n = 0
-	for _,t in vararg(...) do
-		local l = #t
-		if l > n then n = l end
-	end
-	if n == 0 then return end
-	for _,t in vararg(...) do
-		for i = 1, n do
-			t[i] = nil
-		end
-	end
-end
-
-function merge(m,...)
-	for _,t in vararg(...) do
-		for k,v in pairs(t) do
-			m[k] = v
-		end
-	end
-	return m
-end
-
---http://lua-users.org/wiki/VarargTheSecondClassCitizen
-do
-	function vararg(...)
-		local i, t, l = 0, {}
-		local function iter(...)
-			i = i + 1
-			if i > l then return end
-			return i, t[i]
-		end
-		
-		--i = 0
-		l = select("#", ...)
-		for n = 1, l do
-			t[n] = select(n, ...)
-		end
-		--[[
-		for n = l+1, #t do
-			t[n] = nil
-		end
-		--]]
-		return iter
-	end
-end
-
--- MOD SPECIFIC CODE:
-
-proxy = {}
+util.merge(_ENV,util)
+util.merge(_ENV,proxy)
 
 function find_instance(name)
 	for k,v in pairs(gm.CInstance.instances_active) do
@@ -269,12 +12,10 @@ function find_instance(name)
 end
 
 local _repl_globals = {}
-for k,v in pairs(_G) do
-	_repl_globals[k] = v
-end
-for k,v in pairs(_ENV) do
-	_repl_globals[k] = v
-end
+util.merge(_repl_globals,_G)
+util.merge(_repl_globals,_ENV)
+util.merge(_repl_globals,util)
+util.merge(_repl_globals,proxy)
 repl_globals = _repl_globals
 repl_environment = setmetatable({},{
 	__index = repl_globals,
@@ -312,7 +53,7 @@ end
 
 function vararg_tostring(raw, ...)
 	s = ""
-	for _,v in vararg(...) do
+	for _,v in util.vararg(...) do
 		v = raw and tostring(v) or tostring_literal(v)
 		s = s .. '\t' .. v
 	end
@@ -380,9 +121,7 @@ for _,lg in pairs(console_logger) do
 end
 
 function repl_execute_lua(md, env, text, ...)
-	for k,v in pairs(md.definitions) do
-		repl_globals[k] = v
-	end
+	util.merge(repl_globals,md.definitions)
 	local func, err = text, ''
 	if type(text) == "string" then
 		func, err = load( "return " .. text )
@@ -404,7 +143,7 @@ do
 	-- TODO: This needs to be improved regarding properly handling embedded and mixed quotes!
 	local parse_buffer = {}
 	function parse_command_text(text)
-		iclear(parse_buffer)
+		util.iclear(parse_buffer)
 		local spat, epat, buf, quoted = [=[^(['"])]=], [=[(['"])$]=]
 		for str in text:gmatch("%S+") do
 			local squoted = str:match(spat)
@@ -426,7 +165,7 @@ do
 		return true, table.unpack(parse_buffer)
 	end
 	function parse_multicommand_text(text)
-		iclear(parse_buffer)
+		util.iclear(parse_buffer)
 		for mstr in text:gmatch("[^\r\n]+") do
 			local pquoted, buf = 0
 			for str in mstr:gmatch("[^;]+") do
@@ -515,7 +254,7 @@ console_commands = {
 	end,
 	echo = function(md,...)
 		local text = ""
-		for _, arg in vararg(...) do
+		for _, arg in util.vararg(...) do
 			text = text .. ' ' .. arg
 		end
 		text = text:sub(2,#text)
@@ -523,7 +262,7 @@ console_commands = {
 	end,
 	lua = function(md,...)
 		local text = ""
-		for _, arg in vararg(...) do
+		for _, arg in util.vararg(...) do
 			text = text .. ' ' .. arg
 		end
 		text = text:sub(2,#text)
@@ -577,7 +316,7 @@ console_commands = {
 			return
 		end
 		local text = ""
-		for _, arg in vararg(...) do
+		for _, arg in util.vararg(...) do
 			text = text .. ' ' .. arg
 		end
 		text = text:sub(2,#text)
@@ -623,7 +362,7 @@ local function console_mode_definitions(get_md)
 			return console_logger.print(get_md(),true,...)
 		end,
 		tprint = function(...)
-			for _,o in vararg(...) do
+			for _,o in util.vararg(...) do
 				console_logger.print(get_md(),false,o)
 				if type(o) == "table" or type(o) == "userdata" then
 					for k,v in pairs(o) do
@@ -633,7 +372,7 @@ local function console_mode_definitions(get_md)
 			end
 		end,
 		mprint = function(m,...)
-			for _,o in vararg(...) do
+			for _,o in util.vararg(...) do
 				console_logger.print(get_md(),false,o)
 				if type(o) == "table" or type(o) == "userdata" then
 					for k,v in pairs(o) do
@@ -649,7 +388,7 @@ local function console_mode_definitions(get_md)
 end
 
 for mi,md in ipairs(console_modes) do
-	merge(md,{
+	util.merge(md,{
 		current_text = "",
 		enter_pressed = false,
 		history_offset = 0,
@@ -665,7 +404,7 @@ for mi,md in ipairs(console_modes) do
 end
 
 console_mode = console_modes[1]
-merge(_ENV,console_mode_definitions(function() return console_mode end))
+util.merge(_ENV,console_mode_definitions(function() return console_mode end))
 
 do
 	local calculate_text_sizes_x_buffer = {}
@@ -678,7 +417,7 @@ do
 		local my = 0 -- maximum y value in this row
 		local sx = 0 -- sum of x values in this row
 		local n -- number of items in this row
-		for i,t in vararg(...) do
+		for i,t in util.vararg(...) do
 			n = i
 			local x,y = ImGui.CalcTextSize(t)
 			x = x + frame_padding_x_2
@@ -691,390 +430,7 @@ do
 	end
 end
 
-function endow_with_pairs_and_next(sol_object)
-	-- this should be idempotent (does nothing extra when applied more than once)
-	--[[
-	context behind this approach:
-		sol objects are userdata or tables that have sol classes as metatables
-		sol object attributes are functions in their sol class as the same field
-		sol class __index function fallsback to itself so objects inherit class members
-		sol __index generates a new 'new' function whenever it is requested
-		sol classes have stub __pairs that just errors when called
-		sol overrides next to error when that is used on a sol class
-	--]]
-	local sol_meta = getmetatable(sol_object)
-	if not sol_meta then return end
-	local status, sol_next
-	if rawget(sol_meta,'__pairs') or rawget(sol_meta,'__next') then
-		status, sol_next = pcall(pairs,sol_object)
-	end
-	if not status then
-		local sol_index = rawget(sol_meta,'__index')
-		if not sol_index then return end
-		if type(sol_index) ~= 'function' then
-            function sol_next(s,k)
-                return next(sol_index,k)
-            end
-        else
-			function sol_next(s,k)
-				local v,u,w
-				while v == nil do
-					k,u = rawnext(sol_meta,k)
-					if k == nil then return nil end
-					-- ignore 'new' and metatable fields
-					if k ~= 'new' and k:sub(1,2) ~= '__' then
-						w = s[k]
-						-- if the object reports a value different to the class
-						if u ~= w then
-							-- assume it's actually that object's attribute
-							v = w
-						end
-					end
-				end
-				return k,v
-			end
-		end
-		rawset(sol_meta,'__pairs',function(s,k)
-			return sol_next,s,k
-		end)
-	end
-	-- __next is implemented by a custom implementation of next
-	local status = pcall(rawnext,sol_object)
-	if not status and sol_next ~= nil and rawget(sol_meta,'__next') == nil then
-		rawset(sol_meta,'__next',sol_next)
-	end
-end
-
-function endow_with_new_properties(sol_object,properties)
-	local meta = getmetatable(sol_object)
-	local new_properties = {}
-	for k,v in pairs(properties) do
-		if not rawget(meta,k) then
-			new_properties[k] = v
-			rawset(meta,k,v)
-		end
-	end
-	local index = meta.__index
-	meta.__index = function(s,k)
-		local v = new_properties[k]
-		if v then return v(s) end
-		return index(s,k)
-	end
-end
-
-do
-	local function getstring(o)
-		return o.tostring
-	end
-	
-	local function getnumber(o)
-		return tonumber(o.tostring)
-	end
-
-	local function peval(o)
-		local func = load("return " .. o.tostring)
-		if not func then return nil end
-		local status, value = pcall(func)
-		if not status then return nil end
-		return value
-	end
-	
-	local function null()
-		return nil
-	end
-	
-	local function istrue(o)
-		return o.tostring == 'true'
-	end
-
-	local function getarray(o)
-		return o.array
-	end
-
-	rvalue_marshallers = {
-		[RValueType.REAL] = getnumber,
-		[RValueType.STRING] = getstring,
-		[RValueType.ARRAY] = getarray,
-		[RValueType.PTR] = nil,
-		[RValueType.VEC3] = nil,
-		[RValueType.UNDEFINED] = null,
-		[RValueType.OBJECT] = nil,
-		[RValueType.INT32] = getnumber,
-		[RValueType.VEC4] = nil,
-		[RValueType.MATRIX] = nil,
-		[RValueType.INT64] = getnumber,
-		[RValueType.ACCESSOR] = nil,
-		[RValueType.JSNULL] = null,
-		[RValueType.BOOL] = istrue,
-		[RValueType.ITERATOR] = nil,
-		[RValueType.REF] = nil,
-		[RValueType.UNSET] = null
-	}
-
-	function rvalue_marshall(rvalue)
-		local m = rvalue_marshallers[rvalue.type]
-		if m == nil then return rvalue end
-		return m(rvalue)
-	end
-
-	local function get_name(rvalue)
-		return rvalue.tostring
-	end
-
-	local instance_variables_id_register = setmetatable({},{__mode = "k"})
-
-	local instance_variables_proxy_meta = {
-		__index = function(s,k)
-			local id = instance_variables_id_register[s]
-			return rvalue_marshall(gm.variable_instance_get(id,k))
-		end,
-		__newindex = function(s,k,v)
-			local id = instance_variables_id_register[s]
-			return gm.variable_instance_set(id,k,v)
-		end,
-		__next = function(s,k)
-			local id = instance_variables_id_register[s]
-			local names = gm.variable_instance_get_names(id)
-			if names.type ~= RValueType.ARRAY then return nil end
-			names = names.array
-			local i = k and perform_lookup(names,k,get_name) or 0
-			k = names[i+1]
-			if k == nil then return nil end
-			k = k.tostring
-			return k, rvalue_marshall(gm.variable_instance_get(id,k))
-		end,
-		__pairs = function(s,k)
-			local id = instance_variables_id_register[s]
-			local names = gm.variable_instance_get_names(id)
-			if names.type ~= RValueType.ARRAY then return nil end
-			names = names.array
-			local names_lookup = build_lookup(names,get_name)
-			return function(_,k)
-				local i = k and names_lookup[k] or 0
-				k = names[i+1]
-				if k == nil then return nil end
-				k = k.tostring
-				return k, rvalue_marshall(gm.variable_instance_get(id,k))
-			end,s,k
-		end
-	}
-
-	function proxy.variables(cinstance_or_id)
-		if type(cinstance_or_id) ~= 'number' then cinstance_or_id = cinstance_or_id.id end
-		local proxy = setmetatable({},instance_variables_proxy_meta)
-		instance_variables_id_register[proxy] = cinstance_or_id
-		return proxy
-	end
-
-	local struct_id_register = setmetatable({},{__mode = "k"})
-
-	local struct_proxy_meta = {
-		__index = function(s,k)
-			local id = struct_id_register[s]
-			return rvalue_marshall(gm.struct_get(id,k))
-		end,
-		__newindex = function(s,k,v)
-			local id = struct_id_register[s]
-			return gm.struct_set(id,k,v)
-		end,
-		__next = function(s,k)
-			local id = struct_id_register[s]
-			local names = gm.struct_get_names(id)
-			if names.type ~= RValueType.ARRAY then return nil end
-			names = names.array
-			local i = k and perform_lookup(names,k,get_name) or 0
-			k = names[i+1]
-			if k == nil then return nil end
-			k = k.tostring
-			return k, rvalue_marshall(gm.struct_get(id,k))
-		end,
-		__pairs = function(s,k)
-			local id = struct_id_register[s]
-			local names = gm.struct_get_names(id)
-			if names.type ~= RValueType.ARRAY then return nil end
-			names = names.array
-			local names_lookup = build_lookup(names,get_name)
-			return function(_,k)
-				local i = k and names_lookup[k] or 0
-				k = names[i+1]
-				if k == nil then return nil end
-				k = k.tostring
-				return k, rvalue_marshall(gm.struct_get(id,k))
-			end,s,k
-		end
-	}
-
-	proxy.struct = setmetatable({},{
-		__call = function(_,id)
-			local proxy = setmetatable({},struct_proxy_meta)
-			struct_id_register[proxy] = id
-			return proxy
-		end
-	})
-	
-	local struct_variables_id_register = setmetatable({},{__mode = "k"})
-	
-	local struct_variables_proxy_meta = {
-		__index = function(s,k)
-			local id = struct_variables_id_register[s]
-			return rvalue_marshall(gm.variable_struct_get(id,k))
-		end,
-		__newindex = function(s,k,v)
-			local id = struct_variables_id_register[s]
-			return gm.variable_struct_set(id,k,v)
-		end,
-		__next = function(s,k)
-			local id = struct_variables_id_register[s]
-			local names = gm.variable_struct_get_names(id)
-			if names.type ~= RValueType.ARRAY then return nil end
-			names = names.array
-			local i = k and perform_lookup(names,k,get_name) or 0
-			k = names[i+1]
-			if k == nil then return nil end
-			k = k.tostring
-			return k, rvalue_marshall(gm.variable_struct_get(id,k))
-		end,
-		__pairs = function(s,k)
-			local id = struct_variables_id_register[s]
-			local names = gm.variable_struct_get_names(id)
-			if names.type ~= RValueType.ARRAY then return nil end
-			names = names.array
-			local names_lookup = build_lookup(names,get_name)
-			return function(_,k)
-				local i = k and names_lookup[k] or 0
-				k = names[i+1]
-				if k == nil then return nil end
-				k = k.tostring
-				return k, rvalue_marshall(gm.variable_struct_get(id,k))
-			end,s,k
-		end
-	}
-
-	function proxy.struct.variables(id)
-		local proxy = setmetatable({},struct_variables_proxy_meta)
-		struct_variables_id_register[proxy] = id
-		return proxy
-	end
-
-	local global_variables_proxy_meta = {
-		__index = function(s,k)
-			return rvalue_marshall(gm.variable_global_get(k))
-		end,
-		__newindex = function(s,k,v)
-			return gm.variable_global_set(k,v)
-		end,
-		__next = function(s,k)
-			local names = gm.variable_instance_get_names(EVariableType.GLOBAL)
-			if names.type ~= RValueType.ARRAY then return nil end
-			names = names.array
-			local i = k and perform_lookup(names,k,get_name) or 0
-			k = names[i+1]
-			if k == nil then return nil end
-			k = k.tostring
-			return k, rvalue_marshall(gm.variable_global_get(k))
-		end,
-		__pairs = function(s,k)
-			local names = gm.variable_instance_get_names(EVariableType.GLOBAL)
-			if names.type ~= RValueType.ARRAY then return nil end
-			names = names.array
-			local names_lookup = build_lookup(names,get_name)
-			return function(_,k)
-				local i = k and names_lookup[k] or 0
-				k = names[i+1]
-				if k == nil then return nil end
-				k = k.tostring
-				return k, rvalue_marshall(gm.variable_global_get(k))
-			end,s,k
-		end
-	}
-
-	proxy.globals = setmetatable({},global_variables_proxy_meta)
-	
-	local function get_asset(asset_name,asset_type)
-		if asset_type == 'script' then return gm[asset_name] end
-		--return gm.asset_get_index(asset_name)
-		return gm.constants[asset_name]
-	end
-	
-	proxy.constants = {}
-	local constants_lookup = {}
-	local constants_proxy_meta = {}
-	
-	for t,v in pairs(gm.constants_type_sorted) do
-		constants_lookup[t] = build_lookup(v)
-		constants_proxy_meta[t] = {
-			__index = function(s,k)
-				return get_asset(k,t)
-			end,
-			__newindex = function(s,k,v)
-				error(2,"cannot override gamemaker asset.")
-			end,
-			__next = function(s,k)
-				local k = next(constants_lookup[t],k)
-				return k, get_asset(k,t)
-			end,
-			__pairs = function(s,k)
-				return function(s,k)
-					local k = next(constants_lookup[t],k)
-					return k, get_asset(k,t)
-				end,s,k
-			end
-		}
-		proxy.constants[t] = setmetatable({},constants_proxy_meta[t])
-	end
-	
-end
-
-function on_delayed_load()
-
-	local gm_instance_list = gm.CInstance.instances_all
-	local gm_instance = gm_instance_list[1]
-	if not gm_instance then return false end
-	local gm_rvalue = gm.variable_global_get("mouse_x")
-	
-	local imgui_style = ImGui.GetStyle() -- sol.ImGuiStyle*
-	local imgui_vector = imgui_style["WindowPadding"] -- sol.ImVec2*
-	endow_with_pairs_and_next(imgui_style)
-	endow_with_pairs_and_next(imgui_vector)
-
-	endow_with_pairs_and_next(gm_instance_list)
-	endow_with_pairs_and_next(gm_instance)
-	endow_with_pairs_and_next(gm_rvalue)
-	endow_with_pairs_and_next(RValueType)
-	
-	local rvalue_lookup = build_lookup(RValueType)
-	endow_with_new_properties(gm_rvalue,{
-		type_name = function(s) return rvalue_lookup[s.type] end,
-		lua_value = rvalue_marshall
-	})
-	endow_with_new_properties(gm_instance,{
-		variables = proxy.variables
-	})
-	
-	if ImGui.GetStyleVar == nil then
-		local imgui_vector_meta = getmetatable(imgui_vector)
-		local imgui_stylevar_lookup = build_lookup(ImGuiStyleVar)
-		imgui_stylevar_lookup[ImGuiStyleVar.COUNT] = nil
-
-		function ImGui.GetStyleVar(var)
-			if type(var) == "number" then
-				var = imgui_stylevar_lookup[var]
-			end
-			local s = ImGui.GetStyle()[var]
-			if getmetatable(s) ~= imgui_vector_meta then return s end
-			return s['x'],s['y']
-		end
-	end
-	
-	return true
-end
-
-local next_delayed_load = on_delayed_load
-
 function imgui_on_render()
-	if next_delayed_load and next_delayed_load() then
-		next_delayed_load = nil
-	end
 	if ImGui.Begin("Script Console") then
 		if ImGui.BeginTabBar("Mode",ImGuiTabBarFlags.Reorderable) then
 			local item_spacing_x, item_spacing_y = ImGui.GetStyleVar(ImGuiStyleVar.ItemSpacing)
@@ -1103,7 +459,7 @@ function imgui_on_render()
 					ImGui.InvisibleButton("##Spacer" .. ms, x_bar, top_y_max)
 					ImGui.SameLine()
 					if ImGui.Button("Clear##" .. ms, x_clear, top_y_max) then
-						iclear(md.lines_shown,md.lines_raw,md.lines_selected,md.lines_colors)
+						util.iclear(md.lines_shown,md.lines_raw,md.lines_selected,md.lines_colors)
 					end
 					ImGui.SameLine()
 					if ImGui.Button("Copy##" .. ms, x_copy, top_y_max) then

--- a/examples/lua/ReturnOfModding-ScriptConsole/manifest.json
+++ b/examples/lua/ReturnOfModding-ScriptConsole/manifest.json
@@ -1,0 +1,9 @@
+﻿{
+	"name": "ScriptConsole",
+	"version_number": "1.0.0",
+	"website_url": "https://github.com/return-of-modding/ReturnOfModding",
+	"description": "Interactive log terminal, command console, lua REPL",
+	"dependencies": [
+		"ReturnOfModding-ReturnOfModding-1.0.0"
+	]
+}

--- a/examples/lua/ReturnOfModding-ScriptConsole/manifest.json
+++ b/examples/lua/ReturnOfModding-ScriptConsole/manifest.json
@@ -4,6 +4,7 @@
 	"website_url": "https://github.com/return-of-modding/ReturnOfModding",
 	"description": "Interactive log terminal, command console, lua REPL",
 	"dependencies": [
-		"ReturnOfModding-ReturnOfModding-1.0.0"
+		"ReturnOfModding-ReturnOfModding-1.0.0",
+		"ReturnOfModding-GlobalExtensions-1.0.0"
 	]
 }


### PR DESCRIPTION
~~This relies on a speculative change to return of modding:~~
~~that `paths.plugins_data` should return (and possibly create) the folder for a specific mod when that mod's environment is passed in as an argument, i.e. in `paths.plugins_data(_G)` or `paths.plugins_data(_ENV)`, otherwise it will be reading from `plugins_data` directly.~~

~~EDIT: just decided to hardcode that~~
EDIT: now uses the mod specific path provided

This will look for "autoexec.txt" in the plugins_data folder in order to run it, but it won't fail harshly if that doesn't exist.

Still need to fix embedded and mixed quotes in the console to (lines 182 to 241)
Lua notoriously lacks good text handling so I don't expect to personally be able to fix it any time soon.

I also wanted to add "bind" as a command but I don't have access to keycodes in the ImGui bindings exposed to Lua