### PR TITLE
fix(lua): move event deletion from CInstance's destructor to event cleanup

### DIFF
--- a/src/lua/lua_manager_extension.cpp
+++ b/src/lua/lua_manager_extension.cpp
@@ -484,15 +484,16 @@ namespace big::lua_manager_extension
 
 	std::vector<sol::protected_function> get_callbacks(event_map_member_ptr_t map_ptr, CInstance* self, uint32_t event_type, uint32_t event_number)
 	{
+		std::lock_guard guard(g_lua_manager->m_module_lock);
 		std::vector<sol::protected_function> callbacks_to_run;
 
 		for (const auto& module : g_lua_manager->m_modules)
 		{
 			auto mod        = (lua_module_ext*)module.get();
 			const auto& map = (mod->m_data_ext).*map_ptr;
-			uint64_t event_id = gen_event_id(event_type, event_number);
 			if (auto it = map.find(self->id); it != map.end())
 			{
+				uint64_t event_id = gen_event_id(event_type, event_number);
 				const auto& inner_map = it->second;
 				if (auto inner_it = inner_map.find(event_id); inner_it != inner_map.end())
 				{
@@ -509,8 +510,6 @@ namespace big::lua_manager_extension
 
 	bool pre_event_execute(CInstance* self, CInstance* other, int object_index, uint32_t event_type, uint32_t event_number)
 	{
-		std::lock_guard guard(g_lua_manager->m_module_lock);
-
 		bool call_orig_if_true = true;
 		std::vector<sol::protected_function> callback_list = get_callbacks(&big::lua_module_data_ext::m_pre_event_execute_callbacks, self, event_type, event_number);
 		for (const auto& cb : callback_list)
@@ -526,12 +525,20 @@ namespace big::lua_manager_extension
 
 	void post_event_execute(CInstance* self, CInstance* other, int object_index, uint32_t event_type, uint32_t event_number)
 	{
-		std::lock_guard guard(g_lua_manager->m_module_lock);
-
 		std::vector<sol::protected_function> callback_list = get_callbacks(&big::lua_module_data_ext::m_post_event_execute_callbacks, self, event_type, event_number);
 		for (const auto& cb : callback_list)
 		{
 			cb(self, other, object_index);
+		}
+		if (event_type == 12)
+		{
+			std::lock_guard guard(big::g_lua_manager->m_module_lock);
+			for (const auto& module : big::g_lua_manager->m_modules)
+			{
+				auto mod = (big::lua_module_ext*)module.get();
+				mod->m_data_ext.m_pre_event_execute_callbacks.erase(self->id);
+				mod->m_data_ext.m_post_event_execute_callbacks.erase(self->id);
+			}
 		}
 	}
 

--- a/src/rorr/gm/CInstance_hooks.hpp
+++ b/src/rorr/gm/CInstance_hooks.hpp
@@ -2,8 +2,6 @@
 
 #include "CInstance.hpp"
 #include "hooks/hooking.hpp"
-#include "lua/lua_manager.hpp"
-#include "lua/lua_module_ext.hpp"
 
 namespace gm
 {
@@ -40,17 +38,6 @@ namespace gm
 		              });
 
 		CInstance_id_to_CInstance.erase(this_->id);
-
-		if (big::g_lua_manager)
-		{
-			std::lock_guard guard(big::g_lua_manager->m_module_lock);
-			for (const auto& module_ : big::g_lua_manager->m_modules)
-			{
-				auto mod = (big::lua_module_ext*)module_.get();
-				mod->m_data_ext.m_pre_event_execute_callbacks.erase(this_->id);
-				mod->m_data_ext.m_post_event_execute_callbacks.erase(this_->id);
-			}
-		}
 
 		auto* res = big::g_hooking->get_original<hook_CInstance_dctor>()(this_);
 


### PR DESCRIPTION
I think the CInstance's destruction is not thread-safe, so I moved the deletion from the destructor to the cleanup event. This should resolve the hanging issue.
Sorry about the bug in the previous PR.